### PR TITLE
65 defensa general y 73 nada de barbacoas

### DIFF
--- a/app/models/constants.py
+++ b/app/models/constants.py
@@ -10,3 +10,4 @@ class CardName(str, Enum):
     CAMBIO_DE_LUGAR = '¡Cambio de lugar!'
     VIGILA_TUS_ESPALDAS = 'Vigila tus espaldas'
     MAS_VALES_QUE_CORRAS = '¡Más vale que corras!'
+    NADA_DE_BARBACOAS = '¡Nada de barbacoas!'

--- a/app/services/cards.py
+++ b/app/services/cards.py
@@ -43,7 +43,7 @@ class CardsService(DBSessionMixin):
 
     @db_session
     def give_alejate_card(self, player:Player):
-        """ Toma un jugador y le entrega la primera carta de alejate disponible, no modifica los masos
+        """ Toma un jugador y le entrega la primera carta de alejate disponible, no hace shuffle de ser necesario, solo obtiene la carta del maso de descartes
         Returns:
             Carta que se entregó
         """

--- a/app/services/games.py
+++ b/app/services/games.py
@@ -175,6 +175,7 @@ class GamesService(DBSessionMixin):
                 raise InvalidAccionException(f"No se puede jugar {card.name}")
 
             if ps.has_card(player, card) == False:
+                rootlog.exception("Un jugador quiso jugar una carta la cual no era de su pertenencia")
                 raise InvalidCardException()
 
             # obtenemos y verificamos la room
@@ -187,8 +188,17 @@ class GamesService(DBSessionMixin):
                 rootlog.exception(f"No era el turno de la persona que intento jugar {room.machine_state_options['id']} - {player.id}")
                 raise InvalidAccionException("No es tu turno")
 
-            # caso: la carta jugada es lanzallamas ¡ruido de asadoo!
             events = []
+            #veamos si es una carta que se juega sobre alguien
+            if card.need_target == True:
+                target = Player.get(id = card_options["target"])
+                if target in None:
+                    raise InvalidDataException()
+                #veamos si la persona sobre la que se esta jugando la carta tiene la posibilidad de defenderse
+                card_names = map(lambda x:x.name,target.hand)
+                can_defense = any(map(lambda x:x.name in card_names, card.defense_cards))
+                if can_defense:
+                    pass
 
             if card.name == cards.LANZALLAMAS:
                 events.extend(pcs.play_lanzallamas(player, room, card, card_options))

--- a/app/services/play_card.py
+++ b/app/services/play_card.py
@@ -30,17 +30,6 @@ class PlayCardsService(DBSessionMixin):
         if target_player is None or target_player.status != "VIVO":
             raise InvalidAccionException("Objetivo Invalido")
 
-        # veamos que esten al lado
-        if player.position is None or target_player.position is None:
-            # seleccionar una buena excepcion
-            raise Exception()
-        
-        # Vemos que los jugadores esten adyacentes:
-        if abs(player.position - target_player.position) != 1 and \
-            abs(player.position - target_player.position) !=  len(room.players.select(status = "VIVO"))-1:
-            # falta enriquecer con info a este excepcion
-            raise InvalidAccionException("El objetivo no esta al lado tuyo")
-
         events.append({
             'name': 'on_game_player_play_card',
             'body': {

--- a/app/services/play_card.py
+++ b/app/services/play_card.py
@@ -42,12 +42,14 @@ class PlayCardsService(DBSessionMixin):
             raise InvalidAccionException("El objetivo no esta al lado tuyo")
 
         events.append({
-            "name": "on_game_player_death",
-            "body": {
-                "player": target_player.name,
-                "reason": "LANZALLAMAS"
+            'name': 'on_game_player_play_card',
+            'body': {
+                'card_id': card.id,
+                'card_name': card.name,
+                'card_options': card_options,
+                'player_name': player.name,
             },
-            "broadcast": True
+            'broadcast': True
         })
 
         room.kill_player(target_player)
@@ -55,7 +57,8 @@ class PlayCardsService(DBSessionMixin):
         events.append({
             "name": "on_game_player_death",
             "body": {
-                "player": target_player.name
+                "player": target_player.name,
+                "reason": "LANZALLAMAS"
             },
             "broadcast": True
         })

--- a/app/services/play_card.py
+++ b/app/services/play_card.py
@@ -41,7 +41,6 @@ class PlayCardsService(DBSessionMixin):
             # falta enriquecer con info a este excepcion
             raise InvalidAccionException("El objetivo no esta al lado tuyo")
 
-        target_player.status = "MUERTO"  
         events.append({
             "name": "on_game_player_death",
             "body": {
@@ -61,6 +60,27 @@ class PlayCardsService(DBSessionMixin):
             },
             "broadcast": True
         }) 
+        if room.machine_state_options["stage"] == "STARTING" and\
+            len(target_player.hand.select(lambda card : card.name == "¡Nada de barbacoas!")) > 0:
+            #la persona se puede defender
+            room.machine_state =  "PLAYING"
+            room.machine_state_options = {
+                "id" : player.id,
+                "stage" : "FINISHING",
+                "card" : card.name,
+                "card_options" : card_options,
+                "target" : target_player
+            }
+        else:
+            target_player.status = "MUERTO"  
+            events.append({
+                "name": "on_game_player_death",
+                "body": {
+                    "player": target_player.name
+                },
+                "broadcast": True
+            })
+
         return events
 
     @db_session
@@ -409,5 +429,3 @@ class PlayCardsService(DBSessionMixin):
             o de un jugador adyacente
         """
         return []
-
-

--- a/app/services/play_card.py
+++ b/app/services/play_card.py
@@ -62,6 +62,18 @@ class PlayCardsService(DBSessionMixin):
 
         return events
 
+    def play_nada_de_barbacoas(self, player: Player, room: Room, card: Card, card_options):
+        return [{
+            "name": "on_game_player_play_defense_card",
+            "body": {
+                "player_name": player.name,
+                "card_name": card.name,
+                "card_options": card_options,
+                "card_id": card.id
+                },
+            "broadcast": True
+            }]
+
     @db_session
     def play_whisky(self, player: Player, room: Room, card: Card, card_options) -> list[dict]:
         """

--- a/app/services/play_card.py
+++ b/app/services/play_card.py
@@ -50,36 +50,15 @@ class PlayCardsService(DBSessionMixin):
             "broadcast": True
         })
 
+        room.kill_player(target_player)
+
         events.append({
-            "name": "on_game_player_play_card",
+            "name": "on_game_player_death",
             "body": {
-                "card_id": card.id,
-                "card_name": card.name,
-                "card_options": card_options,
-                "player_name": player.name
+                "player": target_player.name
             },
             "broadcast": True
-        }) 
-        if room.machine_state_options["stage"] == "STARTING" and\
-            len(target_player.hand.select(lambda card : card.name == "¡Nada de barbacoas!")) > 0:
-            #la persona se puede defender
-            room.machine_state =  "PLAYING"
-            room.machine_state_options = {
-                "id" : player.id,
-                "stage" : "FINISHING",
-                "card" : card.name,
-                "card_options" : card_options,
-                "target" : target_player
-            }
-        else:
-            target_player.status = "MUERTO"  
-            events.append({
-                "name": "on_game_player_death",
-                "body": {
-                    "player": target_player.name
-                },
-                "broadcast": True
-            })
+        })
 
         return events
 

--- a/app/services/rooms.py
+++ b/app/services/rooms.py
@@ -229,7 +229,8 @@ class RoomsService(DBSessionMixin):
             in_turn_player = self.in_turn_player(room)
             # seteamos el estado del juego para esperar que el proximo jugador juegue
             room.machine_state = "PLAYING"
-            room.machine_state_options = {"id":in_turn_player.id}
+            room.machine_state_options = {"id":in_turn_player.id,
+                                          "stage":"STARTING"}
             from app.services.cards import CardsService
             cs = CardsService(self.db)
             new_card = cs.give_card(in_turn_player)

--- a/app/services/test_games.py
+++ b/app/services/test_games.py
@@ -122,43 +122,6 @@ class TestGamesService(unittest.TestCase):
         assert last_hand_size == len(host.hand) + 1
 
     @db_session
-    def test_play_card_invalid_turn(self):
-        room: Room = self.create_valid_room(
-            roomname="test_play_card_invalid_turn", qty_players=4
-        )
-        sender: Player = list(room.players.select(rol="LA_COSA"))[0]
-
-        card = list(Card.select(lambda x: x.name == "Lanzallamas"))[0]
-
-        host = room.get_host()
-        host.hand.add(card)
-        host.sid = "1234"
-
-        room.status = "IN_GAME"
-        room.machine_state = "PLAYING"
-        room.machine_state_options = {"id": host.id}
-        position = 1
-        next_player = None
-        for player in room.players:
-            if player.id != host.id:
-                if position == 1:
-                    next_player = player
-                player.position = position
-                position += 1
-
-        card2 = list(Card.select(lambda x: x.name == "Lanzallamas"))[1]
-        next_player.hand.add(card2)
-        next_player.sid = "999"
-
-        room.turn = host.position
-
-        ret = self.gs.play_card_manager(
-            "999", {"card": card2.id, "card_options": {"target": host.id}}
-        )
-        assert ret[0]["name"] == "on_game_invalid_action"
-        assert ret[0]["broadcast"] == False
-
-    @db_session
     def test_superinfection(self):
         # primeras excepciones
         room: Room = self.create_valid_room(roomname="test_superinfection", qty_players=4)

--- a/app/services/test_play_card.py
+++ b/app/services/test_play_card.py
@@ -82,6 +82,8 @@ class TestPlayCardsService(unittest.TestCase):
         
         #next_player sera el jugador que sigue de host
         next_player = list(room.players.select(lambda player: player.position == 1))[0]
+        nada_de_barbacoas = Card.select(name = cards.NADA_DE_BARBACOAS)
+        next_player.hand.remove(nada_de_barbacoas)
 
         #seetamos el room para que le toque a host
         room.status = 'IN_GAME'
@@ -93,15 +95,13 @@ class TestPlayCardsService(unittest.TestCase):
         far_player = list(room.players.select(lambda player: player.position == 2))[0]
         
         json =  {'card': card.id, 'card_options': {'target': far_player.id}}
-        ret = self.gs.play_card_manager('test_play_card_lanzallamas', json)
-        assert ret[0]['name'] == 'on_game_invalid_action'
-        assert ret[0]['broadcast'] == False
+        with self.assertRaises(InvalidDataException):
+            self.gs.play_card_manager('test_play_card_lanzallamas', json)
 
         
         #veamos que si la jugamos correctamente se muere el objetivo
         last_hand_size = len(host.hand)
-        ret = self.gs.play_card_manager('test_play_card_lanzallamas', {'card': card.id, 'card_options': {'target': next_player.id}})
-        assert ret[0]['name'] !=  'on_game_invalid_action'
+        self.gs.play_card_manager('test_play_card_lanzallamas', {'card': card.id, 'card_options': {'target': next_player.id}})
         assert next_player.status == 'MUERTO'
         assert len(host.hand) == last_hand_size-1
 

--- a/app/sockets/__init__.py
+++ b/app/sockets/__init__.py
@@ -101,6 +101,8 @@ async def game_play_card(sid : str, data):
     try:
         events = gs.play_card_manager(sid, data)
         await notify_events(events, sid)
+    except InvalidAccionException as e:
+        return e.generate_event(sid)
     except Exception:
         rootlog.exception("ocurrio un error inesperado al jugar una carta, posible estado inconsistente")
     return True

--- a/app/sockets/__init__.py
+++ b/app/sockets/__init__.py
@@ -112,6 +112,8 @@ async def game_play_defense_card(sid :str, data):
     try:
         events = gs.play_defense_card_manager(sid, data)
         await notify_events(events, sid)
+    except InvalidAccionException as e:
+        return e.generate_event(sid)
     except Exception:
         rootlog.exception("ocurrio un error inesperado al defenderse de una carta, posible estado inconsistente")
     return True

--- a/app/sockets/__init__.py
+++ b/app/sockets/__init__.py
@@ -96,7 +96,6 @@ async def room_start_game(sid : str):
         return True
     print(f"Partida iniciada por el jugador con socket_id = {sid}")
 
-    
 @sio_server.event
 async def game_play_card(sid : str, data): 
     try:
@@ -106,6 +105,15 @@ async def game_play_card(sid : str, data):
         rootlog.exception("ocurrio un error inesperado al jugar una carta, posible estado inconsistente")
     return True
 
+@sio_server.event
+async def game_play_defense_card(sid :str, data):
+    try:
+        events = gs.play_defense_card_manager(sid, data)
+        await notify_events(events, sid)
+    except Exception:
+        rootlog.exception("ocurrio un error inesperado al defenderse de una carta, posible estado inconsistente")
+    return True
+    
 @sio_server.event
 async def game_discard_card(sid : str, data): 
     try:


### PR DESCRIPTION
Introduce lógica para manejar defensas de manera generalizada en el servicio de games.

Incluye la implementación de la defensa de "nada de barbacoas" como ejemplo para la implementación de otras cartas de defensa.

La idea es que el código introducido en esta PR soporte todos los tipos de defensa y pueda ser usado luego para implementar la lógica de cada carta de ataque/defensa sin modificarlo.
