### PR TITLE
98 - Descartar cartas de jugador muerto

### DIFF
--- a/app/models/entities.py
+++ b/app/models/entities.py
@@ -239,10 +239,15 @@ class Room(db.Entity):
         # Matar al jugador
         player.status = "MUERTO"
 
+
         # Reordenar al resto de los jugadores.
         # Las posiciones se mantienen de 0 a cantidad de jugadores - 1
 
         room = self
+
+        # Devolver sus cartas al mazo
+        room.discarted_cards.add(player.hand)
+        player.hand.remove(player.hand)
 
         if room.turn is None:
             raise Exception("partida inicializada incorrectamente, turno no pre-seteado")

--- a/app/models/test_entities.py
+++ b/app/models/test_entities.py
@@ -176,9 +176,15 @@ class TestEntities(unittest.TestCase):
 
         with self.assertRaises(InvalidAccionException):
             room.discard_card(host, card)
+    @db_session
+    def test_kill_player(self):
+        room: Room = self.create_valid_room(roomname='test_kill_player')
+        some_player: Player = list(room.players)[0] #type:ignore
 
+        room.kill_player(some_player)
 
-
+        assert len(some_player.hand) == 0
+        assert some_player.status == "MUERTO"
 
     @classmethod
     @db_session


### PR DESCRIPTION
Actualiza operación `kill_player` para descartar mano de jugador muerto.