### PR TITLE
Scrum 74 chat

### DIFF
--- a/app/services/rooms.py
+++ b/app/services/rooms.py
@@ -283,12 +283,12 @@ class RoomsService(DBSessionMixin):
             
 
     @db_session
-    def new_message(sent_sid : str, data):
+    def new_message(self, sent_sid: str, data):
         try:
             return [{
                 "name" : "on_player_new_message",
                 "body" : {
-                    "player_name" : Player.get(sid = sent_sid),
+                    "player_name" : Player.get(sid = sent_sid).name,
                     "message" : data["message"]
                 },
                 "broadcast" : True

--- a/app/sockets/__init__.py
+++ b/app/sockets/__init__.py
@@ -153,7 +153,7 @@ async def game_thething_finish_game(sid: str):
 
 
 @sio_server.event
-async def send_player_message(sid : str, data):
+async def game_new_message(sid : str, data):
     try:
         events = rs.new_message(sid, data)
         await notify_events(events, sid)

--- a/app/sockets/__init__.py
+++ b/app/sockets/__init__.py
@@ -153,7 +153,7 @@ async def game_thething_finish_game(sid: str):
 
 
 @sio_server.event
-async def game_new_message(sid : str, data):
+async def send_player_message(sid : str, data):
     try:
         events = rs.new_message(sid, data)
         await notify_events(events, sid)


### PR DESCRIPTION
Implementa el chat de mensajes por parte del backend, cuando se recibe un mensaje solo se lo reenvia a todos diciendo quien es el autor. No hay persistencia sobre el chat en el backend